### PR TITLE
Add Apple/Google Maps links to addresses

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -28,6 +28,25 @@ layout: default
     {{ content }}
   </div>
 
+  <script>
+    var addressP = document.querySelector('.info__address p');
+    addressP.addEventListener('click', function (event) {
+      const isAppleOS = navigator.platform.match(/(iPhone|iPod|iPad)/i)?true:false;
+
+      const address = addressP.textContent.trim()
+        .replace(/\s{2,}/gm, ' ');
+
+      // Open Apple Maps if OS is iOS
+      if (isAppleOS) {
+        window.open(`maps:?daddr=${address}`, '_self');
+        return;
+      }
+
+      // Open Google Maps app/web on other platforms
+      window.open(`https://www.google.com/maps/dir/?api=1&destination=${address}`, '_self');
+    });
+  </script>
+
   <!-- {% if page.review and page.sample != true %}
     {% if page.next or page.previous %}
       <hr class="divider">

--- a/_sass/average-joe/_post.scss
+++ b/_sass/average-joe/_post.scss
@@ -95,6 +95,11 @@
 
   &__address {
     grid-area: address;
+
+    p:hover {
+      text-decoration: underline;
+      cursor: pointer;
+    }
   }
 
   &__opening {


### PR DESCRIPTION
# Purpose
This PR turns posts' addresses into links to Apple/Google Maps.

# Implementation
- Add JS to query the address element and retrieve the address
- If iOS, open Apple Maps
- Otherwise, open Google Maps